### PR TITLE
enhance file name generator

### DIFF
--- a/models/user_git_repo_collection.go
+++ b/models/user_git_repo_collection.go
@@ -7,19 +7,6 @@ import (
 // ContentFormat represents the format of content in a collection
 type ContentFormat string
 
-const (
-	// FormatMarkdown represents Markdown formatted content
-	FormatMarkdown ContentFormat = "md"
-	// FormatHTML represents HTML formatted content
-	FormatHTML ContentFormat = "html"
-	// FormatYAML represents YAML formatted content
-	FormatYAML ContentFormat = "yaml"
-	// FormatJSON represents JSON formatted content
-	FormatJSON ContentFormat = "json"
-	// FormatText represents plain text content
-	FormatText ContentFormat = "txt"
-)
-
 type Field struct {
 	Type     string `yaml:"type" json:"type"`
 	Name     string `yaml:"name" json:"name"`
@@ -30,49 +17,57 @@ type Field struct {
 	Default  string `yaml:"default,omitempty" json:"default"`
 }
 
+type FileNameGenerator struct {
+	Type  string `yaml:"type" json:"type"`
+	First string `yaml:"first" json:"first"`
+}
+
 // UserGitRepoCollection represents a collection of content within a git repository
 type UserGitRepoCollection struct {
-	ID          uint          `json:"id" gorm:"primaryKey"`
-	Name        string        `json:"name" gorm:"not null"`
-	Label       string        `json:"label" gorm:"not null"`
-	Path        string        `json:"path" gorm:"not null"`
-	Format      ContentFormat `json:"format" gorm:"type:string;not null;default:'md'"`
-	Description string        `json:"description"`
-	RepoID      uint          `json:"repo_id" gorm:"not null"`
-	Repo        UserGitRepo   `json:"repo" gorm:"foreignKey:RepoID"`
-	CreatedAt   time.Time     `json:"created_at"`
-	UpdatedAt   time.Time     `json:"updated_at"`
-	Fields      []Field       `json:"fields" gorm:"foreignKey:CollectionID"`
+	ID                uint               `json:"id" gorm:"primaryKey"`
+	Name              string             `json:"name" gorm:"not null"`
+	Label             string             `json:"label" gorm:"not null"`
+	Path              string             `json:"path" gorm:"not null"`
+	Format            ContentFormat      `json:"format" gorm:"type:string;not null;default:'md'"`
+	Description       string             `json:"description"`
+	RepoID            uint               `json:"repo_id" gorm:"not null"`
+	Repo              UserGitRepo        `json:"repo" gorm:"foreignKey:RepoID"`
+	CreatedAt         time.Time          `json:"created_at"`
+	UpdatedAt         time.Time          `json:"updated_at"`
+	Fields            []Field            `json:"fields" gorm:"foreignKey:CollectionID"`
+	FileNameGenerator *FileNameGenerator `json:"file_name_generator" gorm:"foreignKey:CollectionID"`
 }
 
 // UserGitRepoCollectionResponse is the structure returned to clients
 type UserGitRepoCollectionResponse struct {
-	ID          uint                `json:"id"`
-	Name        string              `json:"name"`
-	Label       string              `json:"label"`
-	Path        string              `json:"path"`
-	Format      ContentFormat       `json:"format"`
-	Description string              `json:"description,omitempty"`
-	RepoID      uint                `json:"repo_id"`
-	Repo        UserGitRepoResponse `json:"repo,omitempty"`
-	CreatedAt   time.Time           `json:"created_at"`
-	UpdatedAt   time.Time           `json:"updated_at"`
-	Fields      []Field             `json:"fields,omitempty"`
+	ID                uint                `json:"id"`
+	Name              string              `json:"name"`
+	Label             string              `json:"label"`
+	Path              string              `json:"path"`
+	Format            ContentFormat       `json:"format"`
+	Description       string              `json:"description,omitempty"`
+	RepoID            uint                `json:"repo_id"`
+	Repo              UserGitRepoResponse `json:"repo,omitempty"`
+	CreatedAt         time.Time           `json:"created_at"`
+	UpdatedAt         time.Time           `json:"updated_at"`
+	Fields            []Field             `json:"fields,omitempty"`
+	FileNameGenerator *FileNameGenerator  `json:"file_name_generator,omitempty"`
 }
 
 // ToResponse converts a UserGitRepoCollection to a UserGitRepoCollectionResponse
 func (c *UserGitRepoCollection) ToResponse(includeRepo bool) UserGitRepoCollectionResponse {
 	response := UserGitRepoCollectionResponse{
-		ID:          c.ID,
-		Name:        c.Name,
-		Label:       c.Label,
-		Path:        c.Path,
-		Format:      c.Format,
-		Description: c.Description,
-		RepoID:      c.RepoID,
-		CreatedAt:   c.CreatedAt,
-		UpdatedAt:   c.UpdatedAt,
-		Fields:      c.Fields,
+		ID:                c.ID,
+		Name:              c.Name,
+		Label:             c.Label,
+		Path:              c.Path,
+		Format:            c.Format,
+		Description:       c.Description,
+		RepoID:            c.RepoID,
+		CreatedAt:         c.CreatedAt,
+		UpdatedAt:         c.UpdatedAt,
+		Fields:            c.Fields,
+		FileNameGenerator: c.FileNameGenerator,
 	}
 
 	if includeRepo {
@@ -85,5 +80,5 @@ func (c *UserGitRepoCollection) ToResponse(includeRepo bool) UserGitRepoCollecti
 // FileUploadRequest represents a request to upload a file
 type FileUploadRequest struct {
 	Path    string `json:"path" binding:"required"`
-	Content string `json:"content" binding:"required"`
+	Content string `json:"content"`
 }

--- a/services/user_git_repo_collection_service.go
+++ b/services/user_git_repo_collection_service.go
@@ -40,11 +40,17 @@ type VedaConfig struct {
 
 // Collection represents a collection in veda/config.yml
 type Collection struct {
-	Name   string  `yaml:"name"`
-	Label  string  `yaml:"label"`
-	Path   string  `yaml:"path"`
-	Format string  `yaml:"format"`
-	Fields []Field `yaml:"fields,omitempty"`
+	Name              string             `yaml:"name"`
+	Label             string             `yaml:"label"`
+	Path              string             `yaml:"path"`
+	Format            string             `yaml:"format"`
+	FileNameGenerator *FileNameGenerator `yaml:"file_name_generator"`
+	Fields            []Field            `yaml:"fields,omitempty"`
+}
+
+type FileNameGenerator struct {
+	Type  string `yaml:"type" json:"type"`
+	First string `yaml:"first" json:"first"`
 }
 
 // Field represents a field in a collection
@@ -147,6 +153,13 @@ func (s *UserGitRepoCollectionService) readCollectionsFromConfig(repo models.Use
 			Description: "", // No description in veda/config.yml
 			RepoID:      repo.ID,
 			Fields:      modelFields,
+		}
+
+		if col.FileNameGenerator != nil {
+			collection.FileNameGenerator = &models.FileNameGenerator{
+				Type:  col.FileNameGenerator.Type,
+				First: col.FileNameGenerator.First,
+			}
 		}
 		collections = append(collections, collection)
 	}

--- a/web/src/app/services/collection.service.ts
+++ b/web/src/app/services/collection.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { AuthService } from '../auth/auth.service';
 import { environment } from '../../environments/environment';
 import {ArrayResponse} from '../shared/core/response';
 

--- a/web/src/app/services/repository.service.ts
+++ b/web/src/app/services/repository.service.ts
@@ -32,6 +32,11 @@ export interface CollectionFieldDefinition {
   default?: any;
 }
 
+export interface FileNameGenerator {
+  type?: string;
+  first?: string
+}
+
 export interface Collection {
   id: number;
   name: string;
@@ -42,6 +47,7 @@ export interface Collection {
   created_at: string;
   updated_at: string;
   fields?: CollectionFieldDefinition[];
+  file_name_generator?: FileNameGenerator
 }
 
 export interface AsyncTask {


### PR DESCRIPTION
1. support file name generator on collection config
    ```yaml
    --- 
    # date
    file_name_generator: 
      type: "date"
    ---
    # seq
    file_name_generator: 
      type: "sequence"
      first: "index" # first file named as index
    ```
3. date will generate file name prefix `2025-07-29-`
4. sequence will find file name number by pattern `^\d+\D+\.md$`, and generate file name prefix `8-`
5. if not configured, generate empty file name